### PR TITLE
Fixes cargo clippy warnings.

### DIFF
--- a/ethane-abi/src/parameter/encode_into.rs
+++ b/ethane-abi/src/parameter/encode_into.rs
@@ -223,10 +223,7 @@ mod test {
         for i in 0..20 {
             let start: usize = 4 + i * 32;
             let end: usize = start + 32;
-            println!("row = {}", i);
             assert_eq!(hash[start..end], expected[start..end]);
         }
-        //assert_eq!(hash[0..32], expected[0..32);
-        //assert_eq!(hash[68..], expected[0..32);
     }
 }

--- a/ethane/test-helper/src/spin_up.rs
+++ b/ethane/test-helper/src/spin_up.rs
@@ -117,7 +117,7 @@ impl ConnectionNodeBundle<WebSocket> {
         let connection =
             Connection::new(WebSocket::new(&format!("ws://{}", process.address), None).unwrap());
         ConnectionNodeBundle {
-            connection: connection,
+            connection,
             process: Some(process),
         }
     }
@@ -128,7 +128,7 @@ impl ConnectionNodeBundle<Http> {
         let process = NodeProcess::new_http("0");
         let connection = Connection::new(Http::new(&format!("http://{}", process.address), None));
         ConnectionNodeBundle {
-            connection: connection,
+            connection,
             process: Some(process),
         }
     }
@@ -136,7 +136,7 @@ impl ConnectionNodeBundle<Http> {
     pub fn ganache() -> Self {
         let connection = Connection::new(Http::new("http://localhost:8545", None));
         ConnectionNodeBundle {
-            connection: connection,
+            connection,
             process: None,
         }
     }
@@ -148,7 +148,7 @@ impl ConnectionNodeBundle<Uds> {
         let process = NodeProcess::new_uds(None);
         let connection = Connection::new(Uds::new(&process.address).unwrap());
         ConnectionNodeBundle {
-            connection: connection,
+            connection,
             process: Some(process),
         }
     }


### PR DESCRIPTION
- Also removes some leftover println statements and comments.
- Aimed to resolve #25