### PR TITLE
I33 decode and display

### DIFF
--- a/ethane-abi/src/lib.rs
+++ b/ethane-abi/src/lib.rs
@@ -122,7 +122,6 @@ impl Abi {
         hash: &[u8],
     ) -> Result<Vec<Parameter>, AbiParserError> {
         if let Some(function) = self.functions.get(function_name) {
-            //let mut start_index = 4_usize; // starting from 5th byte, since the first four is reserved
             let mut start_index = 0;
             let mut parameters = Vec::<Parameter>::with_capacity(function.outputs.len());
             for output in &function.outputs {

--- a/ethane-abi/src/parameter/display.rs
+++ b/ethane-abi/src/parameter/display.rs
@@ -9,7 +9,7 @@ impl fmt::Display for Parameter {
         match self {
             Self::Address(data) => write!(
                 formatter,
-                "Address(0x{})",
+                "0x{}",
                 data.as_bytes()[12..]
                     .iter()
                     .map(|c| format!("{:02x}", c))
@@ -67,7 +67,7 @@ impl fmt::Display for Parameter {
                 // TODO do some conversion based on 2's complement?
                 256 => write!(
                     formatter,
-                    "signed: 0x{}",
+                    "0x{}",
                     data.as_bytes()
                         .iter()
                         .map(|b| format!("{:02x}", b))
@@ -112,10 +112,7 @@ mod test {
                 Address::from_str("0x99429f64cf4d5837620dcc293c1a537d58729b68").unwrap()
             )
         );
-        assert_eq!(
-            &expected,
-            "Address(0x99429f64cf4d5837620dcc293c1a537d58729b68)"
-        );
+        assert_eq!(&expected, "0x99429f64cf4d5837620dcc293c1a537d58729b68");
 
         let expected = format!("{}", Parameter::from(true));
         assert_eq!(&expected, "true");
@@ -176,7 +173,7 @@ mod test {
         let expected = format!("{}", Parameter::new_int([1u8; 32], true));
         assert_eq!(
             &expected,
-            "signed: 0x0101010101010101010101010101010101010101010101010101010101010101"
+            "0x0101010101010101010101010101010101010101010101010101010101010101"
         );
     }
 }

--- a/ethane-abi/src/parameter/mod.rs
+++ b/ethane-abi/src/parameter/mod.rs
@@ -92,8 +92,6 @@ impl Parameter {
             ParameterType::Uint(_) => {
                 let mut bytes = [0u8; 32];
                 bytes.copy_from_slice(&raw_bytes[..32]);
-                println!("bytes len = {}", bytes.len());
-                println!("bytes = {:?}", bytes);
                 (Self::new_int(bytes, false), 32)
             }
             //ParameterType::String  => {

--- a/ethane-abi/src/parameter/parameter_type.rs
+++ b/ethane-abi/src/parameter/parameter_type.rs
@@ -98,19 +98,19 @@ impl ParameterType {
                 "uint" => Self::Uint(256),
                 "string" => Self::String,
                 param_type if param_type.starts_with("int") => {
-                    let len = usize::from_str_radix(&param_type[3..], 10).map_err(|e| {
+                    let len = (&param_type[3..]).parse::<usize>().map_err(|e| {
                         AbiParserError::InvalidAbiEncoding(format!("{}: {}", parsed_str, e))
                     })?;
                     Self::Int(len)
                 }
                 param_type if param_type.starts_with("uint") => {
-                    let len = usize::from_str_radix(&param_type[4..], 10).map_err(|e| {
+                    let len = (&param_type[4..]).parse::<usize>().map_err(|e| {
                         AbiParserError::InvalidAbiEncoding(format!("{}: {}", parsed_str, e))
                     })?;
                     Self::Uint(len)
                 }
                 param_type if param_type.starts_with("bytes") => {
-                    let len = usize::from_str_radix(&param_type[5..], 10).map_err(|e| {
+                    let len = (&param_type[5..]).parse::<usize>().map_err(|e| {
                         AbiParserError::InvalidAbiEncoding(format!("{}: {}", parsed_str, e))
                     })?;
                     Self::FixedBytes(len)

--- a/ethane-abi/tests/abi_parse.rs
+++ b/ethane-abi/tests/abi_parse.rs
@@ -53,4 +53,14 @@ fn test_abi_encode() {
         0000000000000000000000000000000000000000000000000000000000014ddd"
     );
     assert_eq!(hash.unwrap(), expected);
+
+    let returned_parameters = abi.decode("getPrices", &[
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x0a, 0xff,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x0b, 0xff,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x0c, 0xff,
+    ]).unwrap();
+
+    assert_eq!(returned_parameters[0].to_string(), String::from("2815"));
+    assert_eq!(returned_parameters[1].to_string(), String::from("3071"));
+    assert_eq!(returned_parameters[2].to_string(), String::from("3327"));
 }

--- a/ethane-abi/tests/foo.abi
+++ b/ethane-abi/tests/foo.abi
@@ -73,5 +73,25 @@
             }
         ],
         "type": "function"
+    },
+    {
+        "constant": false,
+        "inputs": [],
+        "name": "getPrices",
+        "outputs": [
+            {
+            	"name": "price0",
+            	"type": "uint256"
+            },
+            {
+            	"name": "price1",
+            	"type": "uint256"
+            },
+            {
+            	"name": "timestamp",
+            	"type": "uint256"
+            }
+        ],
+        "type": "function"
     }
 ]


### PR DESCRIPTION
Aims to resolve #33.

## Fixed a major bug in `Parameter::decode`.
The `decode` method was only tested for the case when there was only one return type of a given contract function. `decode` panicked when there were multiple return values because the `copy_from_slice` function was called on slices with different lengths.
## Modified `Display` trait a bit for `Parameter`.
Now if `.to_string()` is called on a `Parameter::Address(value)`, it will output simply the whole hexadecimal address, instead of `Address(0x...)`.
