### PR TITLE
Add cargo update to the github workflow.

### DIFF
--- a/.github/workflows/geth.yml
+++ b/.github/workflows/geth.yml
@@ -42,6 +42,7 @@ jobs:
           sudo add-apt-repository ppa:ethereum/ethereum
           sudo apt-get update
           sudo apt-get install -y solc
+          cargo update
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal


### PR DESCRIPTION
Maybe a `cargo update` is needed to have a matching version number for the crates in the workspace.